### PR TITLE
Add 42 since it works there too

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "41" ],
+    "shell-version": [ "41", "42" ],
     "url": "@PACKAGE_URL@/wiki"
 }


### PR DESCRIPTION
Tested on Ubuntu Jammy Jellyfish + GNOME PPA with gnome-shell 42~alpha.

Preferences works too.

Thanks for this nice and useful extension.